### PR TITLE
ci: bump checkout v7, pnpm/action-setup v6, upload-artifact v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v5
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
         with:
           version: 9
       - uses: actions/setup-node@v6
@@ -30,7 +30,7 @@ jobs:
       - name: Run Smoke Tests
         run: pnpm test
       - name: Upload Playwright Report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: ${{ !cancelled() }}
         with:
           name: playwright-report


### PR DESCRIPTION
## Summary

Combines three low-risk Dependabot GitHub Actions bumps into a single PR:

- `actions/checkout` v6 → v7 (supersedes #38)
- `pnpm/action-setup` v5 → v6 (supersedes #34)
- `actions/upload-artifact` v4 → v7 (supersedes #26)

All three touch only `.github/workflows/ci.yml`. Bundled to keep one clean commit on main and a single deploy.

CI itself validates these (the workflow runs on this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)