### PR TITLE
fix: resolve thumbnails to R2 CDN with branded fallback (sync with cushlabs)

### DIFF
--- a/content/project-overrides.json
+++ b/content/project-overrides.json
@@ -1,19 +1,13 @@
 {
   "ai-portfolio": {
-    "thumbnail": "/images/portfolio-card.webp",
     "video_url": "/video/portfolio-brief.mp4",
     "video_poster": "/images/portfolio-brief-poster.webp"
   },
-  "context-writing-system": {
-    "thumbnail": "/images/thumbs/context-writing-system-thumb.webp"
-  },
   "cushlabs": {
-    "thumbnail": "/images/thumbs/cushlabs-thumb.webp",
     "video_url": "https://cushlabs.ai/images/portfolio/cushlabs-brief.mp4",
     "video_poster": "/images/portfolio/cushlabs-video-poster.jpg"
   },
   "cushlabs-voice-agent": {
-    "thumbnail": "/images/thumbs/cushlabs-voice-agent-thumb.webp",
     "headline": "Never Miss Another Lead Call",
     "subheadline": "AI voice agents that answer every call, qualify leads, and book appointments — 24/7 with sub-500ms response times.",
     "good_for": [
@@ -34,7 +28,6 @@
     ]
   },
   "converso-ai-chatbot-saas": {
-    "thumbnail": "/images/thumbs/converso-ai-chatbot-saas-thumb.webp",
     "headline": "Your Website Loses Leads While You Sleep",
     "subheadline": "White-label AI chatbot that knows your business, speaks your customers' language, and converts visitors into booked calls.",
     "good_for": [
@@ -55,7 +48,6 @@
     ]
   },
   "ny-ai-chatbot": {
-    "thumbnail": "/images/thumbs/ny-ai-chatbot-thumb.webp",
     "headline": "Turn Your Chatbot Into a Revenue Engine",
     "subheadline": "RAG chatbot engineered to convert website visitors into booked strategy sessions — not just answer FAQs.",
     "good_for": [
@@ -76,7 +68,6 @@
     ]
   },
   "ny-english-teacher": {
-    "thumbnail": "/images/thumbs/ny-english-teacher-thumb.webp",
     "headline": "Stop Trading Hours for Leads",
     "subheadline": "Automated lead generation platform that replaces 4 roles — SDR, marketer, assistant, and brand manager — on $0/month infrastructure.",
     "good_for": [
@@ -97,7 +88,6 @@
     ]
   },
   "ai-resume-tailor": {
-    "thumbnail": "/images/thumbs/ai-resume-tailor-thumb.webp",
     "headline": "75% of Resumes Never Reach a Human",
     "subheadline": "AI-powered ATS analysis that shows exactly why resumes get filtered and how to fix them — in under 10 seconds.",
     "good_for": [
@@ -118,7 +108,6 @@
     ]
   },
   "ai-build-vs-outsource": {
-    "thumbnail": "/images/thumbs/ai-build-vs-outsource-thumb.webp",
     "headline": "Stop Guessing on Build vs. Buy Decisions",
     "subheadline": "Interactive decision tools with weighted scoring, cost modeling, and board-ready output that replaces gut-feel arguments.",
     "good_for": [
@@ -138,64 +127,10 @@
       "Shareable URL encoding — full tool state in a link for board presentations"
     ]
   },
-  "ai-idea-validator": {
-    "thumbnail": "/images/thumbs/ai-idea-validator-thumb.webp"
-  },
-  "freelance-income-planner": {
-    "thumbnail": "/images/thumbs/freelance-income-planner-thumb.webp"
-  },
-  "biojalisco-species-id": {
-    "thumbnail": "/images/thumbs/biojalisco-species-id-thumb.webp"
-  },
-  "ai-marketing-suite": {
-    "thumbnail": "/images/thumbs/ai-marketing-suite-thumb.webp"
-  },
-  "cushlabs-scrollytelling": {
-    "thumbnail": "/images/thumbs/cushlabs-scrollytelling-thumb.webp"
-  },
-  "ai-eraser": {},
-  "ai-filesense-website": {
-    "thumbnail": "/images/thumbs/ai-filesense-website-thumb.webp"
-  },
-  "ai-stock-alert": {
-    "thumbnail": "/images/thumbs/ai-stock-alert-thumb.webp"
-  },
-  "ai-filesense": {
-    "thumbnail": "/images/thumbs/ai-filesense-thumb.webp"
-  },
-  "biojalisco-pitch": {
-    "thumbnail": "/images/thumbs/biojalisco-pitch-thumb.webp"
-  },
-  "expatdrive": {
-    "thumbnail": "/images/thumbs/expatdrive-thumb.webp"
-  },
-  "ai-stock-alert-website": {
-    "thumbnail": "/images/thumbs/ai-stock-alert-website-thumb.webp"
-  },
-  "comp-plan-simulator": {
-    "thumbnail": "/images/thumbs/comp-plan-simulator-thumb.webp"
-  },
-  "react-vite-tailwind-base": {
-    "thumbnail": "/images/thumbs/react-vite-tailwind-base-thumb.webp"
-  },
-  "marble-does-not-yield": {
-    "thumbnail": "/images/thumbs/marble-does-not-yield-thumb.webp"
-  },
-  "nextjs-agency-starter": {
-    "thumbnail": "/images/thumbs/nextjs-agency-starter-thumb.webp"
-  },
-  "unwatermark": {
-    "thumbnail": "/images/thumbs/unwatermark-thumb.webp"
-  },
-  "ai-scrabble-practice": {
-    "thumbnail": "/images/thumbs/ai-scrabble-practice-thumb.webp"
-  },
   "mazebreak-gdd-wiki": {
-    "thumbnail": "/images/thumbs/mazebreak-gdd-wiki-thumb.webp",
     "video_url": "https://mazebreak-wiki.vercel.app/video/MazeBreak__Taming_the_GDD.mp4"
   },
   "mazebreak-trello": {
-    "thumbnail": "/images/thumbs/mazebreak-trello-thumb.webp",
     "video_url": "https://mazebreak-trello.vercel.app/video/MazeBreak__Sprint_as_Code.mp4"
   }
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,4 +1,4 @@
-import type { NextConfig } from 'next';
+import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   async headers() {
@@ -7,65 +7,77 @@ const nextConfig: NextConfig = {
         source: "/(.*)",
         headers: [
           { key: "X-DNS-Prefetch-Control", value: "on" },
-          { key: "Strict-Transport-Security", value: "max-age=63072000; includeSubDomains; preload" },
+          {
+            key: "Strict-Transport-Security",
+            value: "max-age=63072000; includeSubDomains; preload",
+          },
           { key: "X-Frame-Options", value: "DENY" },
           { key: "X-Content-Type-Options", value: "nosniff" },
           { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
-          { key: "Permissions-Policy", value: "camera=(), microphone=(), geolocation=()" },
+          {
+            key: "Permissions-Policy",
+            value: "camera=(), microphone=(), geolocation=()",
+          },
         ],
       },
     ];
   },
   images: {
+    // Allow the local branded fallback card (default-card.svg) to render through
+    // next/image. Safe here: the only SVG served is our own trusted local asset,
+    // and it is sandboxed + forced to download disposition by the settings below.
+    dangerouslyAllowSVG: true,
+    contentDispositionType: "attachment",
+    contentSecurityPolicy: "default-src 'self'; script-src 'none'; sandbox;",
     remotePatterns: [
       {
-        protocol: 'https',
-        hostname: 'raw.githubusercontent.com',
+        protocol: "https",
+        hostname: "raw.githubusercontent.com",
       },
       {
-        protocol: 'https',
-        hostname: 'avatars.githubusercontent.com',
+        protocol: "https",
+        hostname: "avatars.githubusercontent.com",
       },
       {
-        protocol: 'https',
-        hostname: 'user-images.githubusercontent.com',
+        protocol: "https",
+        hostname: "user-images.githubusercontent.com",
       },
       {
-        protocol: 'https',
-        hostname: 'opengraph.githubassets.com',
+        protocol: "https",
+        hostname: "opengraph.githubassets.com",
       },
       // Project deploy domains (thumbnails/hero images served from each project's deployment)
       {
-        protocol: 'https',
-        hostname: '*.vercel.app',
+        protocol: "https",
+        hostname: "*.vercel.app",
       },
       {
-        protocol: 'https',
-        hostname: '*.netlify.app',
+        protocol: "https",
+        hostname: "*.netlify.app",
       },
       {
-        protocol: 'https',
-        hostname: 'cushlabs.ai',
+        protocol: "https",
+        hostname: "cushlabs.ai",
       },
       {
-        protocol: 'https',
-        hostname: 'cdn.cushlabs.ai',
+        protocol: "https",
+        hostname: "cdn.cushlabs.ai",
       },
       {
-        protocol: 'https',
-        hostname: 'voice.cushlabs.ai',
+        protocol: "https",
+        hostname: "voice.cushlabs.ai",
       },
       {
-        protocol: 'https',
-        hostname: 'www.nyenglishteacher.com',
+        protocol: "https",
+        hostname: "www.nyenglishteacher.com",
       },
       {
-        protocol: 'https',
-        hostname: 'aistockalert.app',
+        protocol: "https",
+        hostname: "aistockalert.app",
       },
       {
-        protocol: 'https',
-        hostname: 'getexpatdrive.com',
+        protocol: "https",
+        hostname: "getexpatdrive.com",
       },
     ],
   },

--- a/public/images/portfolio/default-card.svg
+++ b/public/images/portfolio/default-card.svg
@@ -1,0 +1,41 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="450" viewBox="0 0 800 450">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0A0A0A"/>
+      <stop offset="100%" style="stop-color:#1a1a1a"/>
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" style="stop-color:#FF6A3D;stop-opacity:0.15"/>
+      <stop offset="100%" style="stop-color:#FF6A3D;stop-opacity:0"/>
+    </radialGradient>
+  </defs>
+  <rect width="800" height="450" fill="url(#bg)"/>
+  <rect width="800" height="450" fill="url(#glow)"/>
+  <!-- Grid pattern -->
+  <g opacity="0.05" stroke="#fff" stroke-width="0.5">
+    <line x1="0" y1="0" x2="0" y2="450"/><line x1="40" y1="0" x2="40" y2="450"/>
+    <line x1="80" y1="0" x2="80" y2="450"/><line x1="120" y1="0" x2="120" y2="450"/>
+    <line x1="160" y1="0" x2="160" y2="450"/><line x1="200" y1="0" x2="200" y2="450"/>
+    <line x1="240" y1="0" x2="240" y2="450"/><line x1="280" y1="0" x2="280" y2="450"/>
+    <line x1="320" y1="0" x2="320" y2="450"/><line x1="360" y1="0" x2="360" y2="450"/>
+    <line x1="400" y1="0" x2="400" y2="450"/><line x1="440" y1="0" x2="440" y2="450"/>
+    <line x1="480" y1="0" x2="480" y2="450"/><line x1="520" y1="0" x2="520" y2="450"/>
+    <line x1="560" y1="0" x2="560" y2="450"/><line x1="600" y1="0" x2="600" y2="450"/>
+    <line x1="640" y1="0" x2="640" y2="450"/><line x1="680" y1="0" x2="680" y2="450"/>
+    <line x1="720" y1="0" x2="720" y2="450"/><line x1="760" y1="0" x2="760" y2="450"/>
+    <line x1="0" y1="0" x2="800" y2="0"/><line x1="0" y1="40" x2="800" y2="40"/>
+    <line x1="0" y1="80" x2="800" y2="80"/><line x1="0" y1="120" x2="800" y2="120"/>
+    <line x1="0" y1="160" x2="800" y2="160"/><line x1="0" y1="200" x2="800" y2="200"/>
+    <line x1="0" y1="240" x2="800" y2="240"/><line x1="0" y1="280" x2="800" y2="280"/>
+    <line x1="0" y1="320" x2="800" y2="320"/><line x1="0" y1="360" x2="800" y2="360"/>
+    <line x1="0" y1="400" x2="800" y2="400"/><line x1="0" y1="440" x2="800" y2="440"/>
+  </g>
+  <!-- Code brackets decoration -->
+  <text x="320" y="200" font-family="monospace" font-size="80" fill="#FF6A3D" opacity="0.12">&lt;/&gt;</text>
+  <!-- Brand text -->
+  <text x="400" y="240" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="24" font-weight="700" letter-spacing="4">
+    <tspan fill="#ffffff">CUSH</tspan><tspan fill="#FF6A3D">LABS.AI</tspan>
+  </text>
+  <!-- Accent line -->
+  <rect x="350" y="260" width="100" height="2" rx="1" fill="#FF6A3D" opacity="0.6"/>
+</svg>

--- a/src/lib/portfolio/loader.ts
+++ b/src/lib/portfolio/loader.ts
@@ -3,7 +3,6 @@ import path from "path";
 import type { PortfolioProject, PortfolioData, HeroImage } from "./types";
 export { filterProjects, sortProjects, searchProjects } from "./filters";
 
-const GITHUB_OWNER = "RCushmaniii";
 const SELF_REPO = "ai-portfolio"; // This app's own repo — local paths stay relative
 const CDN_BASE = "https://cdn.cushlabs.ai"; // Cloudflare R2 CDN for all portfolio assets
 
@@ -49,6 +48,20 @@ function resolveAssetUrl(
   return `${CDN_BASE}/${repoName}${normalizedPath}`;
 }
 
+// Branded fallback card shown when a thumbnail is missing or off-allowlist.
+// Matches the cushlabs site's default-card.svg.
+const BRANDED_FALLBACK = "/images/portfolio/default-card.svg";
+
+// Accept a resolved thumbnail only if it is a local /images/ path or an R2 CDN
+// URL; otherwise return the branded card. Prevents emitting any URL that could
+// 404 (e.g. a private-repo GitHub OpenGraph card).
+function thumbnailOrBranded(url: string | null): string {
+  if (url && (url.startsWith("/images/") || url.startsWith(`${CDN_BASE}/`))) {
+    return url;
+  }
+  return BRANDED_FALLBACK;
+}
+
 // Load order config
 const orderConfigPath = path.join(
   process.cwd(),
@@ -89,13 +102,17 @@ try {
   const rawData = JSON.parse(fs.readFileSync(portfolioPath, "utf-8"));
   const projects = (rawData.projects as PortfolioProject[]).map((p) => {
     const overrides = projectOverrides[p.slug] || {};
-    const thumbnailFallback = `https://opengraph.githubassets.com/1/${GITHUB_OWNER}/${p.repo_name}`;
 
-    // Resolve thumbnail: override takes priority, then PORTFOLIO.md value
-    // Override thumbnails are local to this app (SELF_REPO), not the project's deploy
+    // Resolve thumbnail: optional local override first, then the PORTFOLIO.md
+    // value (which resolves to the Cloudflare R2 CDN for external repos —
+    // matching the cushlabs site, the single canonical asset store).
     const resolvedThumbnail = overrides.thumbnail
       ? resolveAssetUrl(overrides.thumbnail, SELF_REPO)
       : resolveAssetUrl(p.thumbnail, p.repo_name);
+    // Allowlist (mirrors cushlabs' getThumbnail): only emit a local /images/ path
+    // or an R2 CDN URL. Anything else — or a missing thumbnail — degrades to the
+    // branded card, so we never render a 404 or a private-repo GitHub gray card.
+    const thumbnail = thumbnailOrBranded(resolvedThumbnail);
 
     // Resolve hero images — resolve each src while preserving bilingual alt text
     const resolvedHeroImages = p.hero_images
@@ -120,10 +137,10 @@ try {
         orderConfig.featured.length > 0
           ? orderConfig.featured.includes(p.slug)
           : p.portfolio_featured,
-      // Compute thumbnail fallback from GitHub OpenGraph
-      thumbnail_fallback: thumbnailFallback,
-      // Resolved thumbnail with fallback chain
-      thumbnail: resolvedThumbnail || thumbnailFallback,
+      // Branded fallback card (used by the carousel when there are no images)
+      thumbnail_fallback: BRANDED_FALLBACK,
+      // Resolved thumbnail (R2 CDN / local), allowlisted with branded fallback
+      thumbnail,
       // Resolved hero images
       hero_images: resolvedHeroImages,
       // Video fields


### PR DESCRIPTION
## Summary

Brings ai-portfolio's thumbnail resolution **in sync with the cushlabs site** — both now resolve to the canonical Cloudflare R2 store (`cdn.cushlabs.ai`) with a branded fallback, instead of diverging.

### The problem (root cause)
- `project-overrides.json` forced **28 thumbnails to local copies** (`/images/thumbs/...`), serving local files instead of the canonical R2 objects (which already exist).
- **2 private-repo projects** with no thumbnail fell back to a GitHub OpenGraph URL → renders a **gray placeholder card** (the "broken" thumbnails).
- cushlabs never had this: it resolves every thumbnail to R2 and uses a branded `default-card.svg` + an allowlist.

### The fix (match cushlabs)
- **Removed the 28 thumbnail overrides** (kept headline/subheadline/video/good_for/etc.). Every project now resolves to `cdn.cushlabs.ai/{repo}/{path}`.
- **loader.ts allowlist**: only emit `/images/` or `cdn.cushlabs.ai/` URLs; anything else (or missing) → branded `default-card.svg`. Replaces the brittle OpenGraph fallback — can never render a 404 or private-repo gray card.
- Added `public/images/portfolio/default-card.svg` (from cushlabs) + `next.config` allows the trusted local SVG through `next/image` (sandboxed).

### Verification
- **All 32 external thumbnails confirmed to resolve to existing R2 objects (HTTP 200).**
- Self thumb is local-on-disk; the 2 empty private repos (`ny-english-messenger-bot`, `cushlabs-sticker-gen`) now show the branded card instead of a gray GitHub card.
- `pnpm typecheck`, `pnpm build`, `pnpm test` (9/9) all pass; LCP image confirmed loading from R2.

### Distribution after change
32 → R2 · 1 → local (self) · 2 → branded card.

### Follow-up (optional)
Give the 2 empty private repos a real thumbnail (add `thumbnail:` to their `PORTFOLIO.md` + upload to R2 via cushlabs' `upload-to-r2.ts`) to replace their branded card with a real screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)