### PR TITLE
feat: localize category labels (es-MX) + instant search

### DIFF
--- a/src/components/portfolio/CategoryFilter.tsx
+++ b/src/components/portfolio/CategoryFilter.tsx
@@ -1,29 +1,36 @@
-'use client';
+"use client";
 
-import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { t, type Locale } from '@/i18n';
-import type { PortfolioCategory } from '@/lib/portfolio/types';
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { t, type Locale } from "@/i18n";
+import type { PortfolioCategory } from "@/lib/portfolio/types";
 
 interface CategoryFilterProps {
-  value: PortfolioCategory | 'all' | 'featured';
+  value: PortfolioCategory | "all" | "featured";
   onChange: (value: string) => void;
   locale: Locale;
 }
 
-export function CategoryFilter({ value, onChange, locale }: CategoryFilterProps) {
+export function CategoryFilter({
+  value,
+  onChange,
+  locale,
+}: CategoryFilterProps) {
   const dict = t(locale);
 
-  const CATEGORIES: Array<{ value: PortfolioCategory | 'all' | 'featured'; label: string }> = [
-    { value: 'all', label: dict.cat_all },
-    { value: 'featured', label: dict.cat_featured },
-    { value: 'AI Automation', label: 'AI Automation' },
-    { value: 'Developer Tools', label: 'Dev Tools' },
-    { value: 'Templates', label: 'Templates' },
-    { value: 'Tools', label: 'Tools' },
-    { value: 'Client Work', label: 'Client Work' },
-    { value: 'Games', label: 'Games' },
-    { value: 'Marketing', label: 'Marketing' },
-    { value: 'Creative', label: 'Creative' },
+  const CATEGORIES: Array<{
+    value: PortfolioCategory | "all" | "featured";
+    label: string;
+  }> = [
+    { value: "all", label: dict.cat_all },
+    { value: "featured", label: dict.cat_featured },
+    { value: "AI Automation", label: dict.cat_ai_automation },
+    { value: "Developer Tools", label: dict.cat_developer_tools },
+    { value: "Templates", label: dict.cat_templates },
+    { value: "Tools", label: dict.cat_tools },
+    { value: "Client Work", label: dict.cat_client_work },
+    { value: "Games", label: dict.cat_games },
+    { value: "Marketing", label: dict.cat_marketing },
+    { value: "Creative", label: dict.cat_creative },
   ];
 
   return (

--- a/src/components/portfolio/PortfolioGrid.tsx
+++ b/src/components/portfolio/PortfolioGrid.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { useMemo, useState, useRef, useEffect } from "react";
 import { useSearchParams, useRouter, usePathname } from "next/navigation";
 import { ProjectCard } from "./ProjectCard";
 import { CategoryFilter } from "./CategoryFilter";
@@ -74,19 +74,42 @@ export function PortfolioGrid({ projects, locale }: PortfolioGridProps) {
     router.push(`${pathname}?${params.toString()}`, { scroll: false });
   };
 
+  // Instant search: filter on the typed value immediately so the result count
+  // updates with no lag, while the URL (for shareable links) syncs debounced.
+  const [searchTerm, setSearchTerm] = useState(search);
+  const searchTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const lastPushedSearch = useRef(search);
+
+  // Re-sync when the URL search changes externally (clear filters, back/forward).
+  useEffect(() => {
+    if (search !== lastPushedSearch.current) {
+      lastPushedSearch.current = search;
+      setSearchTerm(search);
+    }
+  }, [search]);
+
+  const handleSearchChange = (value: string) => {
+    setSearchTerm(value);
+    if (searchTimer.current) clearTimeout(searchTimer.current);
+    searchTimer.current = setTimeout(() => {
+      lastPushedSearch.current = value;
+      updateParams("search", value);
+    }, 250);
+  };
+
   const filteredAndSorted = useMemo(() => {
-    const searched = searchProjects(projects, search);
+    const searched = searchProjects(projects, searchTerm);
     const filtered = filterProjects(searched, category);
     return sortProjects(filtered, sort);
-  }, [projects, search, category, sort]);
+  }, [projects, searchTerm, category, sort]);
 
   return (
     <div>
       {/* Search */}
       <div className="mb-4">
         <SearchInput
-          value={search}
-          onChange={(value) => updateParams("search", value)}
+          value={searchTerm}
+          onChange={handleSearchChange}
           resultCount={filteredAndSorted.length}
           totalCount={projects.length}
           locale={locale}
@@ -119,12 +142,17 @@ export function PortfolioGrid({ projects, locale }: PortfolioGridProps) {
       {filteredAndSorted.length === 0 ? (
         <div className="text-center py-16">
           <p className="text-muted-foreground mb-4">
-            {search
-              ? interpolate(dict.portfolio_no_results_search, { query: search })
+            {searchTerm
+              ? interpolate(dict.portfolio_no_results_search, {
+                  query: searchTerm,
+                })
               : dict.portfolio_no_results_category}
           </p>
           <button
             onClick={() => {
+              if (searchTimer.current) clearTimeout(searchTimer.current);
+              lastPushedSearch.current = "";
+              setSearchTerm("");
               const params = new URLSearchParams();
               router.push(`${pathname}?${params.toString()}`, {
                 scroll: false,

--- a/src/components/portfolio/SearchInput.tsx
+++ b/src/components/portfolio/SearchInput.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
 import { Search, X } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { t, type Locale } from "@/i18n";
@@ -13,6 +12,10 @@ interface SearchInputProps {
   locale: Locale;
 }
 
+/**
+ * Controlled search box. The parent owns the value and debounces the URL sync,
+ * so filtering is instant as you type (no lag on the result count).
+ */
 export function SearchInput({
   value,
   onChange,
@@ -21,36 +24,6 @@ export function SearchInput({
   locale,
 }: SearchInputProps) {
   const dict = t(locale);
-  const [localValue, setLocalValue] = useState(value);
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  // Sync external value changes (e.g. URL param reset) into the debounced local state.
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional external→local sync
-    setLocalValue(value);
-  }, [value]);
-
-  const handleChange = (newValue: string) => {
-    setLocalValue(newValue);
-    if (timerRef.current) clearTimeout(timerRef.current);
-    timerRef.current = setTimeout(() => {
-      onChange(newValue);
-    }, 300);
-  };
-
-  const handleClear = () => {
-    setLocalValue("");
-    if (timerRef.current) clearTimeout(timerRef.current);
-    onChange("");
-  };
-
-  // Cleanup timer on unmount
-  useEffect(() => {
-    return () => {
-      if (timerRef.current) clearTimeout(timerRef.current);
-    };
-  }, []);
-
   const showCount = value.length > 0;
 
   return (
@@ -60,13 +33,13 @@ export function SearchInput({
         <Input
           type="text"
           placeholder={dict.portfolio_search_placeholder}
-          value={localValue}
-          onChange={(e) => handleChange(e.target.value)}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
           className="pl-9 pr-9 bg-muted/50 border-muted-foreground/20"
         />
-        {localValue && (
+        {value && (
           <button
-            onClick={handleClear}
+            onClick={() => onChange("")}
             className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
             aria-label="Clear search"
           >

--- a/src/i18n/translations/en.ts
+++ b/src/i18n/translations/en.ts
@@ -1,114 +1,128 @@
 export const en = {
   // Nav
-  nav_home: 'Home',
-  nav_portfolio: 'Portfolio',
-  nav_featured: 'Featured',
+  nav_home: "Home",
+  nav_portfolio: "Portfolio",
+  nav_featured: "Featured",
 
   // Homepage
-  home_title: 'CUSHLABS.AI',
-  home_subtitle: 'AI That Works While You Sleep',
+  home_title: "CUSHLABS.AI",
+  home_subtitle: "AI That Works While You Sleep",
   home_description:
-    'We build AI automations that eliminate busywork, speed up response times, and scale your operations — so you can focus on growing your business. Real solutions, already in production.',
-  home_cta: 'See What We Build',
+    "We build AI automations that eliminate busywork, speed up response times, and scale your operations — so you can focus on growing your business. Real solutions, already in production.",
+  home_cta: "See What We Build",
 
   // Featured Work
-  featured_title: 'Featured Work',
-  featured_subtitle: 'AI automations running in production right now',
-  featured_view_project: 'View Project',
-  featured_view_all: 'View all projects',
+  featured_title: "Featured Work",
+  featured_subtitle: "AI automations running in production right now",
+  featured_view_project: "View Project",
+  featured_view_all: "View all projects",
 
   // Featured Page
-  featured_page_title: 'Featured Projects',
-  featured_page_subtitle: 'Our best work — production AI automations delivering real results',
-  featured_card_problem: 'Problem',
-  featured_card_solution: 'Solution',
-  featured_card_outcomes: 'Key Outcomes',
-  featured_card_learn_more: 'Learn More',
+  featured_page_title: "Featured Projects",
+  featured_page_subtitle:
+    "Our best work — production AI automations delivering real results",
+  featured_card_problem: "Problem",
+  featured_card_solution: "Solution",
+  featured_card_outcomes: "Key Outcomes",
+  featured_card_learn_more: "Learn More",
 
   // Mobile Menu
-  mobile_menu_title: 'Menu',
-  mobile_menu_navigation: 'Navigation',
-  mobile_menu_settings: 'Settings',
-  mobile_menu_theme: 'Theme',
-  mobile_menu_language: 'Language',
+  mobile_menu_title: "Menu",
+  mobile_menu_navigation: "Navigation",
+  mobile_menu_settings: "Settings",
+  mobile_menu_theme: "Theme",
+  mobile_menu_language: "Language",
 
   // Portfolio Grid
-  portfolio_title: 'Portfolio',
+  portfolio_title: "Portfolio",
   portfolio_subtitle:
-    'AI-powered solutions and automation projects — {count} projects and counting',
-  portfolio_search_placeholder: 'Search by name, tech stack, or tag...',
-  portfolio_showing: 'Showing {filtered} of {total} projects',
+    "AI-powered solutions and automation projects — {count} projects and counting",
+  portfolio_search_placeholder: "Search by name, tech stack, or tag...",
+  portfolio_showing: "Showing {filtered} of {total} projects",
   portfolio_no_results_search: 'No projects found matching "{query}".',
-  portfolio_no_results_category: 'No projects found in this category.',
-  portfolio_clear_filters: 'Clear filters',
-  portfolio_of: 'of',
-  portfolio_projects: 'projects',
+  portfolio_no_results_category: "No projects found in this category.",
+  portfolio_clear_filters: "Clear filters",
+  portfolio_of: "of",
+  portfolio_projects: "projects",
 
   // Categories
-  cat_all: 'All',
-  cat_featured: 'Featured',
+  cat_all: "All",
+  cat_featured: "Featured",
+  cat_ai_automation: "AI Automation",
+  cat_developer_tools: "Dev Tools",
+  cat_templates: "Templates",
+  cat_tools: "Tools",
+  cat_client_work: "Client Work",
+  cat_games: "Games",
+  cat_marketing: "Marketing",
+  cat_creative: "Creative",
 
   // Sort
-  sort_priority: 'Priority',
-  sort_recent: 'Most Recent',
-  sort_popular: 'Most Popular',
-  sort_by: 'Sort by',
+  sort_priority: "Priority",
+  sort_recent: "Most Recent",
+  sort_popular: "Most Popular",
+  sort_by: "Sort by",
 
   // Card
-  card_view_project: 'View Project',
-  card_featured: 'Featured',
+  card_view_project: "View Project",
+  card_featured: "Featured",
 
   // Detail Page
-  detail_demo_video: 'Demo Video',
-  detail_good_for: 'Good For',
-  detail_not_for: 'Not Ideal For',
-  detail_what_you_get: 'What You Get',
-  detail_problem: 'The Problem',
-  detail_solution: 'The Solution',
-  detail_key_features: 'Key Features',
-  detail_results: 'Results',
-  detail_cta_title: 'Ready to discuss a similar solution?',
-  detail_cta_subtitle: "Let's explore how AI automation can help your business.",
-  detail_cta_button: 'Schedule a Consultation',
+  detail_demo_video: "Demo Video",
+  detail_good_for: "Good For",
+  detail_not_for: "Not Ideal For",
+  detail_what_you_get: "What You Get",
+  detail_problem: "The Problem",
+  detail_solution: "The Solution",
+  detail_key_features: "Key Features",
+  detail_results: "Results",
+  detail_cta_title: "Ready to discuss a similar solution?",
+  detail_cta_subtitle:
+    "Let's explore how AI automation can help your business.",
+  detail_cta_button: "Schedule a Consultation",
 
   // Sidebar
-  sidebar_try_demo: 'Try Demo',
-  sidebar_view_live: 'View Live',
-  sidebar_category: 'Category',
-  sidebar_status: 'Status',
-  sidebar_stars: 'Stars',
-  sidebar_forks: 'Forks',
-  sidebar_language: 'Language',
-  sidebar_completed: 'Completed',
+  sidebar_try_demo: "Try Demo",
+  sidebar_view_live: "View Live",
+  sidebar_category: "Category",
+  sidebar_status: "Status",
+  sidebar_stars: "Stars",
+  sidebar_forks: "Forks",
+  sidebar_language: "Language",
+  sidebar_completed: "Completed",
 
   // Aside
-  aside_tech_stack: 'Tech Stack',
-  aside_topics: 'Topics',
-  aside_tags: 'Tags',
+  aside_tech_stack: "Tech Stack",
+  aside_topics: "Topics",
+  aside_tags: "Tags",
 
   // Breadcrumb
-  breadcrumb_home: 'Home',
-  breadcrumb_portfolio: 'Portfolio',
+  breadcrumb_home: "Home",
+  breadcrumb_portfolio: "Portfolio",
 
   // Footer
-  footer_copyright: '© {year} CUSHLABS AI Services. All rights reserved.',
+  footer_copyright: "© {year} CUSHLABS AI Services. All rights reserved.",
 
   // Metadata
-  meta_title: 'CUSHLABS - AI Consulting & Automation',
-  meta_description: 'AI automation solutions for SMBs in Mexico and LATAM',
-  meta_portfolio_description: 'AI automation projects and solutions by CUSHLABS',
-  meta_not_found: 'Project Not Found',
+  meta_title: "CUSHLABS - AI Consulting & Automation",
+  meta_description: "AI automation solutions for SMBs in Mexico and LATAM",
+  meta_portfolio_description:
+    "AI automation projects and solutions by CUSHLABS",
+  meta_not_found: "Project Not Found",
 
   // Error Pages
-  error_title: 'Something Went Wrong',
-  error_description: 'An unexpected error occurred. This is likely a temporary issue.',
-  error_try_again: 'Try Again',
-  error_go_home: 'Go Home',
-  error_back_portfolio: 'Back to Portfolio',
+  error_title: "Something Went Wrong",
+  error_description:
+    "An unexpected error occurred. This is likely a temporary issue.",
+  error_try_again: "Try Again",
+  error_go_home: "Go Home",
+  error_back_portfolio: "Back to Portfolio",
 
   // Not Found
-  not_found_title: 'Page Not Found',
-  not_found_description: "The page you're looking for doesn't exist or has been moved.",
-  not_found_project_title: 'Project Not Found',
-  not_found_project_description: "The project you're looking for doesn't exist.",
+  not_found_title: "Page Not Found",
+  not_found_description:
+    "The page you're looking for doesn't exist or has been moved.",
+  not_found_project_title: "Project Not Found",
+  not_found_project_description:
+    "The project you're looking for doesn't exist.",
 } as const;

--- a/src/i18n/translations/es.ts
+++ b/src/i18n/translations/es.ts
@@ -50,6 +50,14 @@ export const es = {
   // Categories
   cat_all: "Todos",
   cat_featured: "Destacados",
+  cat_ai_automation: "Automatización con IA",
+  cat_developer_tools: "Herramientas Dev",
+  cat_templates: "Plantillas",
+  cat_tools: "Herramientas",
+  cat_client_work: "Proyectos de Cliente",
+  cat_games: "Juegos",
+  cat_marketing: "Marketing",
+  cat_creative: "Creativo",
 
   // Sort
   sort_priority: "Prioridad",


### PR DESCRIPTION
## Summary

Two portfolio polish items from the review:

### 1. Localized category filter labels (Mexican Professional Spanish)
The category chips (`Dev Tools`, `Templates`, …) were hardcoded English on `/es`. Now localized via new `cat_*` i18n keys — filter **values** stay English (so filtering/URLs are unchanged), only the **labels** translate:

| EN | es-MX |
|----|-------|
| AI Automation | Automatización con IA |
| Dev Tools | Herramientas Dev |
| Templates | Plantillas |
| Tools | Herramientas |
| Client Work | Proyectos de Cliente |
| Games | Juegos |
| Creative | Creativo |

Verified all 10 chips render on `/es/portfolio` via Playwright.

### 2. Instant search (fixes the result-count lag)
The "X of Y" count used to lag ~1s because filtering waited on a URL round-trip. `PortfolioGrid` now filters on the typed value **immediately**, while the URL syncs **debounced (250ms)** for shareable links. Clear-filters and back/forward re-sync correctly. `SearchInput` is now a pure controlled input (removes its internal `set-state-in-effect`).

## Verification
`pnpm typecheck`, `pnpm lint`, `pnpm build`, `pnpm test` (9/9) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)