### PR TITLE
fix: real thumbnails for the two messenger/sticker projects (was branded card)

### DIFF
--- a/content/project-overrides.json
+++ b/content/project-overrides.json
@@ -3,6 +3,12 @@
     "video_url": "/video/portfolio-brief.mp4",
     "video_poster": "/images/portfolio-brief-poster.webp"
   },
+  "ny-english-messenger-bot": {
+    "thumbnail": "https://cdn.cushlabs.ai/ny-english-messenger-bot/public/images/thumb.webp"
+  },
+  "cushlabs-sticker-gen": {
+    "thumbnail": "https://cdn.cushlabs.ai/cushlabs-sticker-gen/docs/images/thumbnail.png"
+  },
   "cushlabs": {
     "video_url": "https://cushlabs.ai/images/portfolio/cushlabs-brief.mp4",
     "video_poster": "/images/portfolio/cushlabs-video-poster.jpg"


### PR DESCRIPTION
## Summary

Fixes the remaining thumbnail discrepancy you spotted: `ny-english-messenger-bot` (and `cushlabs-sticker-gen`) rendered the branded `CUSHLABS.AI` placeholder instead of their real photo — even though the **cushlabs site shows the real image**.

**Root cause:** their `PORTFOLIO.md` `thumbnail` field is empty, so ai-portfolio fell through to the branded fallback. The real thumbnails *do* exist on R2 — the cushlabs site sources them via a `projectDetails` override, which ai-portfolio didn't have.

**Fix:** added thumbnail overrides pointing at the exact R2 objects cushlabs uses:
- `ny-english-messenger-bot` → `cdn.cushlabs.ai/ny-english-messenger-bot/public/images/thumb.webp`
- `cushlabs-sticker-gen` → `cdn.cushlabs.ai/cushlabs-sticker-gen/docs/images/thumbnail.png`

## Diligence
- Ran a **full 35-thumbnail diff** between ai-portfolio and the cushlabs site — only these two were genuinely broken (other diffs were same-image-different-source, both render).
- Both R2 URLs verified **HTTP 200**.
- **Render-checked** with Playwright: searching "messenger" now shows two real photos, **zero branded cards**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)