### PR TITLE
chore: release v1.2.0 — Vercel Analytics, README refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AI Portfolio
 
-![Next.js](https://img.shields.io/badge/Next.js_15-black?style=flat-square&logo=next.js) ![TypeScript](https://img.shields.io/badge/TypeScript-3178C6?style=flat-square&logo=typescript&logoColor=white) ![Tailwind CSS](https://img.shields.io/badge/Tailwind_CSS-06B6D4?style=flat-square&logo=tailwindcss&logoColor=white) ![React 19](https://img.shields.io/badge/React_19-61DAFB?style=flat-square&logo=react&logoColor=black) ![Vercel](https://img.shields.io/badge/Vercel-000?style=flat-square&logo=vercel)
+![Next.js](https://img.shields.io/badge/Next.js_16-black?style=flat-square&logo=next.js) ![TypeScript](https://img.shields.io/badge/TypeScript-3178C6?style=flat-square&logo=typescript&logoColor=white) ![Tailwind CSS](https://img.shields.io/badge/Tailwind_CSS-06B6D4?style=flat-square&logo=tailwindcss&logoColor=white) ![React 19](https://img.shields.io/badge/React_19-61DAFB?style=flat-square&logo=react&logoColor=black) ![Vercel](https://img.shields.io/badge/Vercel-000?style=flat-square&logo=vercel)
 
 > A bilingual (EN/ES) static portfolio system that aggregates project data from GitHub repositories and renders a professional, filterable showcase with SEO optimization and WebP images.
 
@@ -49,11 +49,12 @@ On the display side, Next.js App Router serves statically-generated pages. A ser
 - **Server/client component split**: Pages load data server-side via `fs`; filtering runs client-side via pure functions in `filters.ts`
 - **URL-driven state**: Category and sort selections stored in search params for shareable, bookmarkable filtered views
 - **Order override system**: A `portfolio-order.json` config controls display priority and featured badges without code changes
-- **Bilingual (EN/ES)**: Full internationalization with middleware-based locale routing
-- **WebP images**: All local images converted to WebP (93% size reduction)
-- **SEO optimized**: Dynamic sitemap, robots.txt, JSON-LD structured data, canonical URLs, theme-color
+- **Bilingual (EN/ES)**: Full internationalization with middleware-based locale routing, per-locale `<html lang>`, and descriptive bilingual (`alt_en`/`alt_es`) image alt text
+- **R2 CDN assets**: Project thumbnails and hero images resolve to a Cloudflare R2 store (`cdn.cushlabs.ai`) with a branded fallback card — no broken images
+- **Instant client-side search**: Results filter as you type while the URL syncs debounced for shareable links
+- **SEO optimized**: Dynamic sitemap with `hreflang` alternates, robots.txt, JSON-LD structured data (Organization, BreadcrumbList, SoftwareApplication), canonical URLs, Open Graph + Twitter cards
 - **Dark mode**: System-preference-aware theme switching via `next-themes`
-- **Image security**: `next.config.ts` restricts remote images to GitHub-hosted domains only
+- **Resilient sync**: Tolerant YAML parsing recovers malformed frontmatter (logged, never silently dropped); disabled repos skip cleanly
 - **shadcn/ui components**: Accessible, Tailwind-native UI components with consistent design tokens
 
 ## Getting Started
@@ -80,10 +81,10 @@ Copy the example file and add your GitHub token:
 cp .env.example .env
 ```
 
-| Variable | Required | Description |
-|----------|----------|-------------|
-| `GITHUB_TOKEN` | Yes (sync only) | Personal access token for GitHub API |
-| `NEXT_PUBLIC_SITE_URL` | No | Base URL for OG images |
+| Variable               | Required        | Description                          |
+| ---------------------- | --------------- | ------------------------------------ |
+| `GITHUB_TOKEN`         | Yes (sync only) | Personal access token for GitHub API |
+| `NEXT_PUBLIC_SITE_URL` | No              | Base URL for OG images               |
 
 ### Running Locally
 
@@ -118,11 +119,11 @@ ai-portfolio/
 │   └── generate-portfolio.ts    # PORTFOLIO.md generator
 ├── src/
 │   ├── app/
-│   │   ├── layout.tsx           # Root layout (viewport/theme-color)
+│   │   ├── layout.tsx           # Pass-through root (html/lang lives per-locale)
 │   │   ├── sitemap.ts           # Dynamic sitemap with i18n alternates
 │   │   ├── robots.ts            # Robots.txt (allow all)
 │   │   └── [locale]/
-│   │       ├── layout.tsx       # Locale layout (metadata, JSON-LD)
+│   │       ├── layout.tsx       # Locale layout (html lang, metadata, JSON-LD)
 │   │       ├── page.tsx         # Home page
 │   │       ├── featured/        # Featured projects page
 │   │       └── portfolio/
@@ -162,9 +163,9 @@ The sync script doesn't just log to stdout — it tracks problems and reports th
 
 **What gets tracked:**
 
-| Level | Examples |
-|-------|---------|
-| Error | 403 Forbidden (token access), invalid PORTFOLIO.md frontmatter |
+| Level   | Examples                                                                    |
+| ------- | --------------------------------------------------------------------------- |
+| Error   | 403 Forbidden (token access), invalid PORTFOLIO.md frontmatter              |
 | Warning | Missing tagline, thumbnail, tech stack, problem description, or screenshots |
 
 **How it works:**
@@ -180,16 +181,23 @@ The sync script doesn't just log to stdout — it tracks problems and reports th
 
 ```markdown
 ## Errors (1)
+
 ### `some-repo`
+
 - 403 Forbidden — token lacks access to this repo
 
 ## Warnings (2)
+
 ### `mazebreak-trello`
+
 - Missing problem/challenge description
+
 ### `mazebreak-wiki`
+
 - Missing problem/challenge description
 
 ## How to Fix
+
 - **403 Forbidden**: Check that your GITHUB_TOKEN has public_repo scope...
 - **Missing fields**: Add the missing content to the repo's PORTFOLIO.md...
 ```
@@ -197,14 +205,16 @@ The sync script doesn't just log to stdout — it tracks problems and reports th
 ## Results
 
 **Portfolio System:**
-- 21 active projects displayed across 8 categories
+
+- 35 active projects displayed across 9 categories
 - Content managed entirely through PORTFOLIO.md files in source repositories
 - Zero runtime API calls — fully static, sub-second page loads
 - Featured project highlighting and priority-based ordering without code changes
 
 **Technical Demonstration:**
+
 - End-to-end TypeScript with strict mode and Zod validation at the data boundary
-- Clean server/client component architecture in Next.js 15 App Router
+- Clean server/client component architecture in Next.js 16 App Router
 - URL-driven filter state for shareable, bookmarkable views
 - Backward-compatible schema transforms for evolving data formats
 
@@ -223,4 +233,4 @@ Guadalajara, Mexico
 
 ---
 
-*Last Updated: 2026-03-02*
+_Last Updated: 2026-06-28_

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-portfolio",
-  "version": "0.1.0",
+  "version": "1.2.0",
   "private": true,
   "scripts": {
     "dev": "next dev",
@@ -21,6 +21,7 @@
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-tabs": "^1.1.13",
+    "@vercel/analytics": "^2.0.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "embla-carousel-react": "^8.5.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,6 +28,9 @@ importers:
       '@radix-ui/react-tabs':
         specifier: ^1.1.13
         version: 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@vercel/analytics':
+        specifier: ^2.0.1
+        version: 2.0.1(next@16.2.9(@babel/core@7.29.7)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -1198,6 +1201,35 @@ packages:
     resolution: {integrity: sha512-nAB74NfSNKknqQ1RrYj6uz8FcXEomu/MATJZxh/x+BArzN2U3JbOYC0APYzUIGhVY3m5hRxA8VPNdPBoG8txlA==}
     cpu: [x64]
     os: [win32]
+
+  '@vercel/analytics@2.0.1':
+    resolution: {integrity: sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==}
+    peerDependencies:
+      '@remix-run/react': ^2
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      nuxt: '>= 3'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@remix-run/react':
+        optional: true
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      nuxt:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -3903,6 +3935,11 @@ snapshots:
 
   '@unrs/resolver-binding-win32-x64-msvc@1.12.2':
     optional: true
+
+  '@vercel/analytics@2.0.1(next@16.2.9(@babel/core@7.29.7)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
+    optionalDependencies:
+      next: 16.2.9(@babel/core@7.29.7)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
 
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata, Viewport } from "next";
 import { Inter } from "next/font/google";
 import { notFound } from "next/navigation";
+import { Analytics } from "@vercel/analytics/next";
 import { ThemeProvider } from "@/components/ThemeProvider";
 import { SiteHeader } from "@/components/SiteHeader";
 import { SiteFooter } from "@/components/SiteFooter";
@@ -125,6 +126,7 @@ export default async function LocaleLayout({ children, params }: Props) {
             <SiteFooter locale={locale} />
             <ScrollToTop />
           </div>
+          <Analytics />
         </ThemeProvider>
       </body>
     </html>


### PR DESCRIPTION
## Summary

Release-prep for **v1.2.0**, wrapping up this round of work.

- **Vercel Web Analytics** added (`@vercel/analytics` in the locale layout) — supersedes the stale auto-generated integration PR #21, which targeted the now-restructured root layout.
- **README refreshed** to current reality: Next.js 16, 35 projects across 9 categories, R2 CDN thumbnails + branded fallback, bilingual alt text, instant search, resilient sync; updated structure notes, live-demo link, and date.
- **Version** bumped `0.1.0 → 1.2.0`.

Verified: typecheck, lint, build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)