### PR TITLE
fix(contact): correct LinkedIn URL slug

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ Business Solution Architect & Full-Stack Developer
 Guadalajara, Mexico
 
 📧 info@cushlabs.ai
-🔗 [GitHub](https://github.com/RCushmaniii) • [LinkedIn](https://linkedin.com/in/robertcushman) • [Portfolio](https://cushlabs.ai)
+🔗 [GitHub](https://github.com/RCushmaniii) • [LinkedIn](https://linkedin.com/in/robert-cushman3) • [Portfolio](https://cushlabs.ai)
 
 ## License
 

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -117,7 +117,7 @@ export default async function LocaleLayout({ children, params }: Props) {
                 },
                 sameAs: [
                   "https://github.com/RCushmaniii",
-                  "https://linkedin.com/in/robertcushman",
+                  "https://linkedin.com/in/robert-cushman3",
                 ],
               }}
             />


### PR DESCRIPTION
Corrects the LinkedIn URL slug `robertcushman` -> `robert-cushman3` in the README and deployed source (footer / JSON-LD). One-line string fix, no functional change.